### PR TITLE
Add support for chain to lang

### DIFF
--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -133,6 +133,7 @@ The possible syntax for `[parser]` are:
 - `[parser]*` a parser that matches `[parser]` zero or more times
 - `[parser]+` a parser that matches `[parser]` one or more times
 - `[parser] > ${f}` a parser that matches `[parser]` and then `map`s the result with `f`
+- `[parser] >> ${f}` a parser that matches `[parser]` and then `chain`s the result with `f`
 
 For example,
 

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   ],
   "scripts": {
     "lint": "prettier --check src/*.js",
-    "test": "ava"
+    "test": "ava --tap"
   },
   "author": "Tim Disney",
   "license": "MIT",

--- a/test/test-lang.js
+++ b/test/test-lang.js
@@ -1,6 +1,6 @@
 import test from 'ava';
 import lang from '../src/lang';
-import { empty } from '../src/parser';
+import { empty, succeed } from '../src/parser';
 
 test('lang with a single token literal rule', t => {
   let { a } = lang`
@@ -258,6 +258,14 @@ test('lang with multiple maps that associate to the left', t => {
   `;
 
   t.deepEqual(a.tryParse('a'), 'ab');
+});
+
+test('lang with a chain', t => {
+  let { a } = lang`
+    a = 'a' >> ${value => succeed({ value })} ;
+  `;
+
+  t.deepEqual(a.tryParse('a'), { value: 'a' });
 });
 
 test('calc language', t => {


### PR DESCRIPTION
You can now use `>>` to do chaining in the template:

```js
let { a } = lang`
a = 'a' >> ${() => Parser.of(42)}
`
```